### PR TITLE
Allows passthrough of DOM node attribute values.

### DIFF
--- a/lib/active_admin/editor/parser_rules.rb
+++ b/lib/active_admin/editor/parser_rules.rb
@@ -169,7 +169,7 @@ module ActiveAdmin
           'rename_tag' => 'span'
         },
         'iframe' => {
-          'remove' => 1
+          'remove' => 0
         },
         'figcaption' => {
           'rename_tag' => 'div'

--- a/lib/active_admin/editor/version.rb
+++ b/lib/active_admin/editor/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module Editor
-    VERSION = '1.1.4'
+    VERSION = '1.1.5'
   end
 end

--- a/vendor/assets/javascripts/wysihtml5.js
+++ b/vendor/assets/javascripts/wysihtml5.js
@@ -5106,6 +5106,16 @@ wysihtml5.dom.parse = (function() {
         return attributeValue.replace(REG_EXP, "");
       };
     })(),
+
+    // Just copies the attribute untouched.
+    passThrough: (function() {
+      return function(attributeValue) {
+        if (!attributeValue) {
+          return "";
+        }
+        return attributeValue;
+      };
+    })(),
     
     numbers: (function() {
       var REG_EXP = /\D/g;


### PR DESCRIPTION
Adds a passThrough value for checked_attributes.
Adding something like:-

``` ruby
  config.parser_rules['tags']['iframe'] = {
    'check_attributes' => {
      'src' => 'src',
      'height' => 'passThrough',
      'width' => 'passThrough'
    }
  }
```

will send a value through the wysiwyg editor intact.
Changes the default value for iframe from remove to include.
